### PR TITLE
修正实例运行行参数错误

### DIFF
--- a/tools/simnet/train/tf/README.md
+++ b/tools/simnet/train/tf/README.md
@@ -74,7 +74,7 @@ python tools/tf_record_writer.py
 ```
 python tf_simnet.py
         --task train
-        --task_conf examples/cnn_pointwise.json
+        --task_conf examples/cnn-pointwise.json
 ```
 **参数说明：**
 * **task**: 任务类型 ，可选择train或predict。
@@ -138,7 +138,7 @@ python tf_simnet.py
 ```
 python tf_simnet.py
         --task predict
-        --task_conf examples/cnn_pointwise.json
+        --task_conf examples/cnn-pointwise.json
 ```
 **参数说明：**
 同模型训练部分


### PR DESCRIPTION
按照原来READme中的运行参数会报错，修改完后不会，方便初学者使用